### PR TITLE
Remove global static initializers from loader

### DIFF
--- a/src/loader/loader_instance.cpp
+++ b/src/loader/loader_instance.cpp
@@ -42,22 +42,25 @@
 #include <vector>
 
 namespace {
-std::unique_ptr<LoaderInstance> g_current_loader_instance;
+std::unique_ptr<LoaderInstance>& GetSetCurrentLoaderInstance() {
+    static std::unique_ptr<LoaderInstance> current_loader_instance;
+    return current_loader_instance;
 }
+}  // namespace
 
 namespace ActiveLoaderInstance {
 XrResult Set(std::unique_ptr<LoaderInstance> loader_instance, const char* log_function_name) {
-    if (g_current_loader_instance != nullptr) {
+    if (GetSetCurrentLoaderInstance() != nullptr) {
         LoaderLogger::LogErrorMessage(log_function_name, "Active XrInstance handle already exists");
         return XR_ERROR_LIMIT_REACHED;
     }
 
-    g_current_loader_instance = std::move(loader_instance);
+    GetSetCurrentLoaderInstance() = std::move(loader_instance);
     return XR_SUCCESS;
 }
 
 XrResult Get(LoaderInstance** loader_instance, const char* log_function_name) {
-    *loader_instance = g_current_loader_instance.get();
+    *loader_instance = GetSetCurrentLoaderInstance().get();
     if (*loader_instance == nullptr) {
         LoaderLogger::LogErrorMessage(log_function_name, "No active XrInstance handle.");
         return XR_ERROR_HANDLE_INVALID;
@@ -66,9 +69,9 @@ XrResult Get(LoaderInstance** loader_instance, const char* log_function_name) {
     return XR_SUCCESS;
 }
 
-bool IsAvailable() { return g_current_loader_instance != nullptr; }
+bool IsAvailable() { return GetSetCurrentLoaderInstance() != nullptr; }
 
-void Remove() { g_current_loader_instance.release(); }
+void Remove() { GetSetCurrentLoaderInstance().release(); }
 }  // namespace ActiveLoaderInstance
 
 // Extensions that are supported by the loader, but may not be supported

--- a/src/loader/loader_logger.cpp
+++ b/src/loader/loader_logger.cpp
@@ -36,9 +36,6 @@
 #include <utility>
 #include <vector>
 
-std::unique_ptr<LoaderLogger> LoaderLogger::_instance;
-std::once_flag LoaderLogger::_once_flag;
-
 bool LoaderLogRecorder::LogDebugUtilsMessage(XrDebugUtilsMessageSeverityFlagsEXT /*message_severity*/,
                                              XrDebugUtilsMessageTypeFlagsEXT /*message_type*/,
                                              const XrDebugUtilsMessengerCallbackDataEXT* /*callback_data*/) {

--- a/src/loader/loader_logger.hpp
+++ b/src/loader/loader_logger.hpp
@@ -117,8 +117,8 @@ class LoaderLogRecorder {
 class LoaderLogger {
    public:
     static LoaderLogger& GetInstance() {
-        std::call_once(LoaderLogger::_once_flag, []() { _instance.reset(new LoaderLogger); });
-        return *(_instance.get());
+        static LoaderLogger instance;
+        return instance;
     }
 
     void AddLogRecorder(std::unique_ptr<LoaderLogRecorder>&& recorder);
@@ -175,9 +175,6 @@ class LoaderLogger {
 
    private:
     LoaderLogger();
-
-    static std::unique_ptr<LoaderLogger> _instance;
-    static std::once_flag _once_flag;
 
     // List of available recorder objects
     std::vector<std::unique_ptr<LoaderLogRecorder>> _recorders;

--- a/src/loader/runtime_interface.cpp
+++ b/src/loader/runtime_interface.cpp
@@ -35,12 +35,11 @@
 #include <utility>
 #include <vector>
 
-std::unique_ptr<RuntimeInterface> RuntimeInterface::_single_runtime_interface;
 uint32_t RuntimeInterface::_single_runtime_count = 0;
 
 XrResult RuntimeInterface::LoadRuntime(const std::string& openxr_command) {
     // If something's already loaded, we're done here.
-    if (_single_runtime_interface != nullptr) {
+    if (GetInstance() != nullptr) {
         _single_runtime_count++;
         return XR_SUCCESS;
     }
@@ -148,19 +147,19 @@ XrResult RuntimeInterface::LoadRuntime(const std::string& openxr_command) {
             LoaderLogger::LogInfoMessage(openxr_command, info_message);
 
             // Use this runtime
-            _single_runtime_interface.reset(new RuntimeInterface(runtime_library, runtime_info.getInstanceProcAddr));
+            GetInstance().reset(new RuntimeInterface(runtime_library, runtime_info.getInstanceProcAddr));
             _single_runtime_count++;
 
             // Grab the list of extensions this runtime supports for easy filtering after the
             // xrCreateInstance call
             std::vector<std::string> supported_extensions;
             std::vector<XrExtensionProperties> extension_properties;
-            _single_runtime_interface->GetInstanceExtensionProperties(extension_properties);
+            GetInstance()->GetInstanceExtensionProperties(extension_properties);
             supported_extensions.reserve(extension_properties.size());
             for (XrExtensionProperties ext_prop : extension_properties) {
                 supported_extensions.emplace_back(ext_prop.extensionName);
             }
-            _single_runtime_interface->SetSupportedExtensions(supported_extensions);
+            GetInstance()->SetSupportedExtensions(supported_extensions);
 
             // If we load one, clear all errors.
             any_loaded = true;
@@ -184,7 +183,7 @@ XrResult RuntimeInterface::LoadRuntime(const std::string& openxr_command) {
 void RuntimeInterface::UnloadRuntime(const std::string& openxr_command) {
     if (_single_runtime_count == 1) {
         _single_runtime_count = 0;
-        _single_runtime_interface.reset();
+        GetInstance().reset();
     } else if (_single_runtime_count > 0) {
         --_single_runtime_count;
     }
@@ -192,14 +191,14 @@ void RuntimeInterface::UnloadRuntime(const std::string& openxr_command) {
 }
 
 XrResult RuntimeInterface::GetInstanceProcAddr(XrInstance instance, const char* name, PFN_xrVoidFunction* function) {
-    return _single_runtime_interface->_get_instance_proc_addr(instance, name, function);
+    return GetInstance()->_get_instance_proc_addr(instance, name, function);
 }
 
 const XrGeneratedDispatchTable* RuntimeInterface::GetDispatchTable(XrInstance instance) {
     XrGeneratedDispatchTable* table = nullptr;
-    std::lock_guard<std::mutex> mlock(_single_runtime_interface->_dispatch_table_mutex);
-    auto it = _single_runtime_interface->_dispatch_table_map.find(instance);
-    if (it != _single_runtime_interface->_dispatch_table_map.end()) {
+    std::lock_guard<std::mutex> mlock(GetInstance()->_dispatch_table_mutex);
+    auto it = GetInstance()->_dispatch_table_map.find(instance);
+    if (it != GetInstance()->_dispatch_table_map.end()) {
         table = it->second.get();
     }
     return table;
@@ -208,9 +207,9 @@ const XrGeneratedDispatchTable* RuntimeInterface::GetDispatchTable(XrInstance in
 const XrGeneratedDispatchTable* RuntimeInterface::GetDebugUtilsMessengerDispatchTable(XrDebugUtilsMessengerEXT messenger) {
     XrInstance runtime_instance = XR_NULL_HANDLE;
     {
-        std::lock_guard<std::mutex> mlock(_single_runtime_interface->_messenger_to_instance_mutex);
-        auto it = _single_runtime_interface->_messenger_to_instance_map.find(messenger);
-        if (it != _single_runtime_interface->_messenger_to_instance_map.end()) {
+        std::lock_guard<std::mutex> mlock(GetInstance()->_messenger_to_instance_mutex);
+        auto it = GetInstance()->_messenger_to_instance_map.find(messenger);
+        if (it != GetInstance()->_messenger_to_instance_map.end()) {
             runtime_instance = it->second;
         }
     }

--- a/src/loader/runtime_interface.hpp
+++ b/src/loader/runtime_interface.hpp
@@ -38,7 +38,7 @@ class RuntimeInterface {
     // Helper functions for loading and unloading the runtime (but only when necessary)
     static XrResult LoadRuntime(const std::string& openxr_command);
     static void UnloadRuntime(const std::string& openxr_command);
-    static RuntimeInterface& GetRuntime() { return *(_single_runtime_interface.get()); }
+    static RuntimeInterface& GetRuntime() { return *(GetInstance().get()); }
     static XrResult GetInstanceProcAddr(XrInstance instance, const char* name, PFN_xrVoidFunction* function);
 
     // Get the direct dispatch table to this runtime, without API layers or loader terminators.
@@ -63,7 +63,11 @@ class RuntimeInterface {
     RuntimeInterface(LoaderPlatformLibraryHandle runtime_library, PFN_xrGetInstanceProcAddr get_instance_proc_addr);
     void SetSupportedExtensions(std::vector<std::string>& supported_extensions);
 
-    static std::unique_ptr<RuntimeInterface> _single_runtime_interface;
+    static std::unique_ptr<RuntimeInterface>& GetInstance() {
+      static std::unique_ptr<RuntimeInterface> instance;
+      return instance;
+    }
+
     static uint32_t _single_runtime_count;
     LoaderPlatformLibraryHandle _runtime_library;
     PFN_xrGetInstanceProcAddr _get_instance_proc_addr;


### PR DESCRIPTION
This change replaces global static initializers with functions that return static locals.  With this change code that includes OpenXR doesn't have to page in this code and initialize these during startup.