### PR TITLE
Fix not finding 'wayland-client.h' in submodule build

### DIFF
--- a/src/common/xr_dependencies.h
+++ b/src/common/xr_dependencies.h
@@ -85,5 +85,5 @@
 #endif  // XR_USE_GRAPHICS_API_VULKAN
 
 #ifdef XR_USE_PLATFORM_WAYLAND
-#include "wayland-client.h"
+#include <wayland/wayland-client.h>
 #endif  // XR_USE_PLATFORM_WAYLAND

--- a/src/common/xr_dependencies.h
+++ b/src/common/xr_dependencies.h
@@ -85,5 +85,5 @@
 #endif  // XR_USE_GRAPHICS_API_VULKAN
 
 #ifdef XR_USE_PLATFORM_WAYLAND
-#include <wayland/wayland-client.h>
+#include "wayland-client.h"
 #endif  // XR_USE_PLATFORM_WAYLAND

--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -108,6 +108,7 @@ target_include_directories(
             # for target-specific generated files
             ${CMAKE_CURRENT_SOURCE_DIR}
             ${CMAKE_CURRENT_BINARY_DIR}
+            ${WAYLAND_CLIENT_INCLUDE_DIRS}
     INTERFACE $<INSTALL_INTERFACE:include>
 )
 


### PR DESCRIPTION
Building openxr when included as a submodule in another project fails because the mentioned header file was not found.